### PR TITLE
Make sure that metric names are escaped using the same algorithm which Icinga 2 uses

### DIFF
--- a/library/Graphite/Grapher.php
+++ b/library/Graphite/Grapher.php
@@ -103,9 +103,11 @@ class Grapher extends GrapherHook
 
     private function graphitify($str)
     {
-        $str=str_replace('-','_',$str);
-        $str=str_replace('.','_',$str);
         $str=str_replace(' ','_',$str);
+        $str=str_replace('.','_',$str);
+        $str=str_replace('-','_',$str);
+        $str=str_replace('\\','_',$str);
+        $str=str_replace('/','_',$str);
         return $str;
     }
 


### PR DESCRIPTION
In addition to the characters that are already getting escaped Icinga also escapes backslashes as well as forward slashes:

```
String GraphiteWriter::EscapeMetric(const String& str)
{
        String result = str;

        boost::replace_all(result, " ", "_");
        boost::replace_all(result, ".", "_");
        boost::replace_all(result, "-", "_");
        boost::replace_all(result, "\\", "_");
        boost::replace_all(result, "/", "_");

        return result;
}
```

This patch updates the `graphitify` method to escape all the characters which Icinga 2 escapes.
