### PR TITLE
Remove the str_replace call on . from the grapher

### DIFF
--- a/library/Graphite/Grapher.php
+++ b/library/Graphite/Grapher.php
@@ -76,7 +76,7 @@ class Grapher extends GrapherHook
         if  ($service != '_HOST_' ){
             $target .= '.'. $this->graphitify($service);
         }
-        $target .= '.'. $this->graphitify($metric);
+        $target .= '.'. $this->graphitify($metric, true);
         $imgUrl = sprintf(
             '%s&target=%s.%s&source=0&width=100&height=40&hideAxes=true&lineWidth=2&hideLegend=true&colorList=049BAF',
             $this->baseUrl,
@@ -101,9 +101,13 @@ class Grapher extends GrapherHook
        );
     }
 
-    private function graphitify($str)
+    private function graphitify($str, $isMetric = false)
     {
         $str=str_replace(' ','_',$str);
+        if (!$metric_flag)
+        {
+            $str=str_replace('.','_',$str);
+        }
         $str=str_replace('-','_',$str);
         $str=str_replace('\\','_',$str);
         $str=str_replace('/','_',$str);
@@ -116,7 +120,7 @@ class Grapher extends GrapherHook
         if  ($service != '_HOST_' ){
             $target .= '.'. $this->graphitify($service);
         }
-        $target .= '.'. $this->graphitify($metric);
+        $target .= '.'. $this->graphitify($metric, true);
         $imgUrl = sprintf(
             '%s&target=%s.%s&source=0&width=300&height=120&hideAxes=true&lineWidth=2&hideLegend=true&colorList=049BAF',
             $this->baseUrl,

--- a/library/Graphite/Grapher.php
+++ b/library/Graphite/Grapher.php
@@ -104,7 +104,7 @@ class Grapher extends GrapherHook
     private function graphitify($str, $isMetric = false)
     {
         $str=str_replace(' ','_',$str);
-        if (!$metric_flag)
+        if (!$isMetric)
         {
             $str=str_replace('.','_',$str);
         }

--- a/library/Graphite/Grapher.php
+++ b/library/Graphite/Grapher.php
@@ -104,7 +104,6 @@ class Grapher extends GrapherHook
     private function graphitify($str)
     {
         $str=str_replace(' ','_',$str);
-        $str=str_replace('.','_',$str);
         $str=str_replace('-','_',$str);
         $str=str_replace('\\','_',$str);
         $str=str_replace('/','_',$str);


### PR DESCRIPTION
Hey @philiphoy ,

First of all many thanks for the great job you have done on that plugin!

I just faced one issue with it, let me tell you more about it.

I am using NRPE in my Icinga2 configuration. I end up with the following tree in Graphite:

![image](https://cloud.githubusercontent.com/assets/1719652/7042363/36ddc422-dd96-11e4-894b-0112fb3ca371.png)

As you can see, If the '.' is escaped, I can not reach my metrics given that they are under a subfolder.

My Icinga2 configuration looks like this, and it works just fine:

``` ruby
template Host "nrpe-host" {
  import "generic-host"
  enable_perfdata = true
  vars.graphite_keys = [ "nrpe_load.load1", "nrpe_load.load5" ]
  ...
}
```

Let me know if I am doing something wrong! Any feedback will be welcomed!

Thanks again,

Florian
