### PR TITLE
UI Improvements

### DIFF
--- a/application/controllers/IndexController.php
+++ b/application/controllers/IndexController.php
@@ -7,7 +7,7 @@ class Graphite_IndexController extends ActionController
     public function indexAction()
     {
         $this->view->url = sprintf(
-            '%s&target=%s.%s&source=0&width=800&height=700&colorList=049BAF',
+            '%s&target=%s.%s&source=0&width=800&height=700&colorList=049BAF&lineMode=connected',
             $this->getParam('base_url'),
             $this->getParam('metric_prefix'),
             $this->getParam('target')

--- a/application/views/scripts/index/index.phtml
+++ b/application/views/scripts/index/index.phtml
@@ -1,8 +1,15 @@
-<ul>
-<li><a target="graph_iframe" href="<?= urldecode($this->url) ?>&from=-10min">10 minutes</a></li>
-<li><a target="graph_iframe" href="<?= urldecode($this->url) ?>&from=-1h">1 hour</a></li>
-<li><a target="graph_iframe" href="<?= urldecode($this->url) ?>&from=-12h" active>12 hour</a></li>
-<li><a target="graph_iframe" href="<?= urldecode($this->url) ?>&from=-1d">1 day</a></li>
-<li><a target="graph_iframe" href="<?= urldecode($this->url) ?>&from=-1w">1 week</a></li>
-</ul>
-<iframe name ="graph_iframe" src="<?= urldecode($this->url) ?>&from=-1d" style="height: 99%; width:100%" frameborder="no"></iframe>
+<div class="controls">
+    <?= $tabs->showOnlyCloseButton() ?>
+</div>
+<div class="content">
+  <table class="avp" style="width: 800px; text-align: center;">
+    <tr>
+      <td><a target="graph_iframe" class="icon-clock" href="<?= urldecode($this->url) ?>&from=-10min">10 minutes</a></td>
+      <td><a target="graph_iframe" class="icon-clock" href="<?= urldecode($this->url) ?>&from=-1h">1 hour</a></td>
+      <td><a target="graph_iframe" class="icon-clock" href="<?= urldecode($this->url) ?>&from=-12h" active>12 hours</a></td>
+      <td><a target="graph_iframe" class="icon-clock" href="<?= urldecode($this->url) ?>&from=-1d">1 day</a></td>
+      <td><a target="graph_iframe" class="icon-clock" href="<?= urldecode($this->url) ?>&from=-1w">1 week</a></td>
+    </tr>
+  </table>
+  <iframe name ="graph_iframe" src="<?= urldecode($this->url) ?>&from=-1d" style="height: 700px; width: 800px" frameborder="no"></iframe>
+</div>

--- a/application/views/scripts/index/index.phtml
+++ b/application/views/scripts/index/index.phtml
@@ -9,6 +9,8 @@
       <td><a target="graph_iframe" class="icon-clock" href="<?= urldecode($this->url) ?>&from=-12h" active>12 hours</a></td>
       <td><a target="graph_iframe" class="icon-clock" href="<?= urldecode($this->url) ?>&from=-1d">1 day</a></td>
       <td><a target="graph_iframe" class="icon-clock" href="<?= urldecode($this->url) ?>&from=-1w">1 week</a></td>
+      <td><a target="graph_iframe" class="icon-clock" href="<?= urldecode($this->url) ?>&from=-1mon">1 month</a></td>
+      <td><a target="graph_iframe" class="icon-clock" href="<?= urldecode($this->url) ?>&from=-1y">1 year</a></td>
     </tr>
   </table>
   <iframe name ="graph_iframe" src="<?= urldecode($this->url) ?>&from=-1d" style="height: 700px; width: 800px" frameborder="no"></iframe>


### PR DESCRIPTION
Two UI improvements:
## connected graph mode

When using a check interval larger than 1 minute, the generated graph show dots instead of lines.
This comes from the `storage-schemas.conf` snippet shipped with this module:

```
[icinga_default]
pattern = ^icinga\.
retentions = 1m:2d,5m:10d,30m:90d,360m:4y
```

The finest data granularity is 1m here. This force the user to remove the `1m:2d` part of this or to change its `check_interval` to 1m, which is quite high when you have a lot of machines to monitor.

Anyway, using `lineMode=connected` will get graphs right all the time. The only drawback is that you won't notice if there is missing data from time to time.
## UI improvements

The changes improve the graph UI, by making it a bit more compact and coherent with the overall icingaweb2 UI, by adding the tab controls (to close the tab) and reusing existing CSS.
(Table was used instead of a list because it allows to re-use some of icingaweb2 css, and it's ok because it's actual tabular data)
