### PR TITLE
Added legacyMode option

### DIFF
--- a/application/views/scripts/config/index.phtml
+++ b/application/views/scripts/config/index.phtml
@@ -9,8 +9,13 @@
 [graphite]
 metric_prefix = icinga2
 base_url = http://graphite.com/render?
-service_name_template = "$host.name$.services.$service.name$.$service.check_command$"
-host_name_template = "$host.name$.host.$host.check_command$"
+legacy_mode = false
+;if legacy mode is false (2.4 and newer):
+service_name_template = "$host.name$.services.$service.name$.$service.check_command$.perfdata"
+host_name_template = "$host.name$.host.$host.check_command$.perfdata"
+;if legacy mode is true (pre 2.4):
+;service_name_template = "$host.name$.services.$service.name$.$service.check_command$"
+;host_name_template = "$host.name$.host.$host.check_command$"
 ;this template is used for the small image, macro $target$ can used.
 graphite_args_template = "&target=$target$&source=0&width=300&height=120&hideAxes=true&lineWidth=2&hideLegend=true&colorList=049BAF"
 ;this template is used for the large image, macro $target$ can used. 

--- a/library/Graphite/Grapher.php
+++ b/library/Graphite/Grapher.php
@@ -22,12 +22,14 @@ class Grapher extends GrapherHook
     protected $hostMacro = '$HOSTNAME$';
     protected $imageUrlMacro = '&target=$target$&source=0&width=300&height=120&hideAxes=true&lineWidth=2&hideLegend=true&colorList=049BAF';
     protected $largeImageUrlMacro = '&target=$target$&source=0&width=800&height=700&colorList=049BAF&lineMode=connected';
+    protected $legacyMode = 'false';
 
     protected function init()
     {
         $cfg = Config::module('graphite')->getSection('graphite');
         $this->baseUrl = rtrim($cfg->get('base_url', $this->baseUrl), '/');
         $this->metricPrefix = $cfg->get('metric_prefix', $this->metricPrefix);
+        $this->legacyMode = $cfg->get('legacy_mode', $this->legacyMode);
         $this->serviceMacro = $cfg->get('service_name_template', $this->serviceMacro);
         $this->hostMacro = $cfg->get('host_name_template', $this->hostMacro);
         $this->imageUrlMacro = $cfg->get('graphite_args_template', $this->imageUrlMacro);
@@ -102,6 +104,11 @@ class Grapher extends GrapherHook
         }
 
         $target .= '.'. Macro::escapeMetric($metric);
+
+        if ($this->legacyMode == 'false'){
+            $target .= '.value';
+        }
+
         $target = $this->metricPrefix . "." . $target;
 
 


### PR DESCRIPTION
Now supports the new graphite structure from icinga2 2.4 and onwards, with legacyMode option for backwards compability.
Icinga2 2.6 looks to be the last to support legacy structure.
Examples for both LegacyMode true and false now in the configuration examples, default is the new.
