### PR TITLE
Add possibility to fetch and embed graphs from remote server

### DIFF
--- a/application/controllers/IndexController.php
+++ b/application/controllers/IndexController.php
@@ -1,11 +1,44 @@
 <?php
 
 use Icinga\Web\Controller\ActionController;
+use Icinga\Web\Url;
 
 class Graphite_IndexController extends ActionController
 {
+    protected $grapher;
+
+    public function init()
+    {
+	$this->grapher = new \Icinga\Module\Graphite\Grapher;
+    }
+
     public function indexAction()
     {
-        $this->view->url = $this->getParam('graphite_url');
+
+        if ($this->grapher->getRemoteFetch()) {
+	    $this->view->url = $this->_request->getScheme()."://".
+                               $this->_request->getHttpHost().
+		               Url::fromPath('graphite/index/graph', array(
+                                   'target' => $this->getParam('graphite_url')
+  	                       ));
+        } else {
+            $this->view->url = urldecode($this->getParam('graphite_url'));
+        }
+    }
+
+    public function graphAction()
+    {
+        $this->_helper->layout()->disableLayout();
+
+	$target = $this->getParam('target');
+        
+	$largeImgUrl = $this->grapher->getLargeImgUrl($target);
+
+	if ($this->grapher->getRemoteFetch()) {
+	    $largeImgUrl = $this->grapher->inlineImage($largeImgUrl);
+        } 
+
+	$this->view->largeImgUrl = $largeImgUrl;
+	$this->view->target = $target;
     }
 }

--- a/application/controllers/IndexController.php
+++ b/application/controllers/IndexController.php
@@ -31,8 +31,9 @@ class Graphite_IndexController extends ActionController
         $this->_helper->layout()->disableLayout();
 
 	$target = $this->getParam('target');
+	$from = $this->getParam('from');
         
-	$largeImgUrl = $this->grapher->getLargeImgUrl($target);
+	$largeImgUrl = $this->grapher->getLargeImgUrl($target, $from);
 
 	if ($this->grapher->getRemoteFetch()) {
 	    $largeImgUrl = $this->grapher->inlineImage($largeImgUrl);

--- a/application/views/scripts/config/index.phtml
+++ b/application/views/scripts/config/index.phtml
@@ -9,6 +9,14 @@
 [graphite]
 metric_prefix = icinga2
 base_url = http://graphite.com/render?
+
+; fetch remote image and inline the data
+remote_fetch = true
+; verify remote certificate
+remote_verify_peer = true
+; verify remote peer name
+remote_verify_peer_name = true
+
 legacy_mode = false
 ;if legacy mode is false (2.4 and newer):
 service_name_template = "$host.name$.services.$service.name$.$service.check_command$.perfdata"

--- a/application/views/scripts/index/graph.phtml
+++ b/application/views/scripts/index/graph.phtml
@@ -1,0 +1,1 @@
+<img src="<?= $this->largeImgUrl ?>" alt="<?= $this->target ?>" border="0" />

--- a/application/views/scripts/index/index.phtml
+++ b/application/views/scripts/index/index.phtml
@@ -4,14 +4,14 @@
 <div class="content">
   <table class="avp" style="width: 800px; text-align: center;">
     <tr>
-      <td><a target="graph_iframe" class="icon-clock" href="<?= urldecode($this->url) ?>&from=-10min">10 minutes</a></td>
-      <td><a target="graph_iframe" class="icon-clock" href="<?= urldecode($this->url) ?>&from=-1h">1 hour</a></td>
-      <td><a target="graph_iframe" class="icon-clock" href="<?= urldecode($this->url) ?>&from=-12h" active>12 hours</a></td>
-      <td><a target="graph_iframe" class="icon-clock" href="<?= urldecode($this->url) ?>&from=-1d">1 day</a></td>
-      <td><a target="graph_iframe" class="icon-clock" href="<?= urldecode($this->url) ?>&from=-1w">1 week</a></td>
-      <td><a target="graph_iframe" class="icon-clock" href="<?= urldecode($this->url) ?>&from=-1mon">1 month</a></td>
-      <td><a target="graph_iframe" class="icon-clock" href="<?= urldecode($this->url) ?>&from=-1y">1 year</a></td>
+      <td><a target="graph_iframe" class="icon-clock" href="<?= $this->url ?>&from=-10min">10 minutes</a></td>
+      <td><a target="graph_iframe" class="icon-clock" href="<?= $this->url ?>&from=-1h">1 hour</a></td>
+      <td><a target="graph_iframe" class="icon-clock" href="<?= $this->url ?>&from=-12h" active>12 hours</a></td>
+      <td><a target="graph_iframe" class="icon-clock" href="<?= $this->url ?>&from=-1d">1 day</a></td>
+      <td><a target="graph_iframe" class="icon-clock" href="<?= $this->url ?>&from=-1w">1 week</a></td>
+      <td><a target="graph_iframe" class="icon-clock" href="<?= $this->url ?>&from=-1mon">1 month</a></td>
+      <td><a target="graph_iframe" class="icon-clock" href="<?= $this->url ?>&from=-1y">1 year</a></td>
     </tr>
   </table>
-  <iframe name ="graph_iframe" src="<?= urldecode($this->url) ?>&from=-1d" style="height: 700px; width: 800px" frameborder="no"></iframe>
+  <iframe name ="graph_iframe" src="<?= $this->url ?>&from=-1d" style="height: 800px; width: 900px" frameborder="no"></iframe>
 </div>

--- a/library/Graphite/Grapher.php
+++ b/library/Graphite/Grapher.php
@@ -118,19 +118,16 @@ class Grapher extends GrapherHook
         }
 
         $target = $this->metricPrefix . "." . $target;
-
 	$imgUrl = $this->getImgUrl($target);
-	$largeImgUrl = $this->getLargeImgUrl($target);
 
 	if ($this->remoteFetch) {
 	    $imgUrl = $this->inlineImage($imgUrl);
-	    $largeImgUrl = $this->inlineImage($largeImgUrl);
             $url = Url::fromPath('graphite', array(
 		'graphite_url' => urlencode($target),
 	    ));
 	} else {
             $url = Url::fromPath('graphite', array(
-                'graphite_url' => urlencode($largeImgUrl)
+                'graphite_url' => urlencode($this->getLargeImgUrl($target))
             ));
 	}
 
@@ -165,7 +162,12 @@ class Grapher extends GrapherHook
 	return $this->baseUrl . Macro::resolveMacros($this->imageUrlMacro, array("target" => $target), $this->legacyMode, false);
     }
 
-    public function getLargeImgUrl($target) {
-       	return $this->baseUrl . Macro::resolveMacros($this->largeImageUrlMacro, array("target" => $target), $this->legacyMode,  false);
+    public function getLargeImgUrl($target, $from=false) {
+       	$url = $this->baseUrl . Macro::resolveMacros($this->largeImageUrlMacro, array("target" => $target), $this->legacyMode,  false);
+	if ($from !== false) {
+		$url = $url.'&from='.$from;
+	}
+
+	return $url;
     }
 }

--- a/library/Graphite/Grapher.php
+++ b/library/Graphite/Grapher.php
@@ -24,6 +24,10 @@ class Grapher extends GrapherHook
     protected $largeImageUrlMacro = '&target=$target$&source=0&width=800&height=700&colorList=049BAF&lineMode=connected';
     protected $legacyMode = 'false';
 
+    protected $remoteFetch = false;
+    protected $remoteVerifyPeer = true;
+    protected $remoteVerifyPeerName = true;
+
     protected function init()
     {
         $cfg = Config::module('graphite')->getSection('graphite');
@@ -34,6 +38,10 @@ class Grapher extends GrapherHook
         $this->hostMacro = $cfg->get('host_name_template', $this->hostMacro);
         $this->imageUrlMacro = $cfg->get('graphite_args_template', $this->imageUrlMacro);
         $this->largeImageUrlMacro = $cfg->get('graphite_large_args_template', $this->largeImageUrlMacro);
+
+        $this->remoteFetch = $cfg->get('remote_fetch', $this->remoteFetch);
+        $this->remoteVerifyPeer = $cfg->get('remote_verify_peer', $this->remoteVerifyPeer);
+        $this->remoteVerifyPeerName = $cfg->get('remote_verify_peer_name', $this->remoteVerifyPeerName);
     }
 
     public function has(MonitoredObject $object)
@@ -111,14 +119,20 @@ class Grapher extends GrapherHook
 
         $target = $this->metricPrefix . "." . $target;
 
+	$imgUrl = $this->getImgUrl($target);
+	$largeImgUrl = $this->getLargeImgUrl($target);
 
-        $imgUrl = $this->baseUrl . Macro::resolveMacros($this->imageUrlMacro, array("target" => $target), $this->legacyMode, false);
-
-        $largeImgUrl = $this->baseUrl . Macro::resolveMacros($this->largeImageUrlMacro, array("target" => $target), $this->legacyMode,  false);
-
-        $url = Url::fromPath('graphite', array(
-            'graphite_url' => urlencode($largeImgUrl)
-        ));
+	if ($this->remoteFetch) {
+	    $imgUrl = $this->inlineImage($imgUrl);
+	    $largeImgUrl = $this->inlineImage($largeImgUrl);
+            $url = Url::fromPath('graphite', array(
+		'graphite_url' => urlencode($target),
+	    ));
+	} else {
+            $url = Url::fromPath('graphite', array(
+                'graphite_url' => urlencode($largeImgUrl)
+            ));
+	}
 
         $html = '<a href="%s" title="%s"><img src="%s" alt="%s" width="300" height="120" /></a>';
 
@@ -129,5 +143,29 @@ class Grapher extends GrapherHook
             $imgUrl,
             $metric
        );
+    }
+
+    public function inlineImage($url) {
+        $ctx = stream_context_create(array('ssl' => array("verify_peer"=>$this->remoteVerifyPeer, "verify_peer_name"=>$this->remoteVerifyPeerName)));
+
+        $img = @file_get_contents($url, false, $ctx);
+        $error = error_get_last();
+        if ($error === null) {
+            return 'data:image/png;base64,'.base64_encode($img);
+        } else {
+            throw new \ErrorException($error['message']);
+        }
+    }
+
+    public function getRemoteFetch() {
+        return $this->remoteFetch;
+    }
+
+    public function getImgUrl($target) {
+	return $this->baseUrl . Macro::resolveMacros($this->imageUrlMacro, array("target" => $target), $this->legacyMode, false);
+    }
+
+    public function getLargeImgUrl($target) {
+       	return $this->baseUrl . Macro::resolveMacros($this->largeImageUrlMacro, array("target" => $target), $this->legacyMode,  false);
     }
 }


### PR DESCRIPTION
Add possibility to fetch and embed graphs from remote server accessible to icingaweb2 user.

For example local graphite installation not exposed to public or a password protected instance.

New config variables:

remote_fetch = true
remote_verify_peer = true
remote_verify_peer_name = true
