### PR TITLE
Prevent scrolling in iframe (Firefox)

### DIFF
--- a/application/views/scripts/index/index.phtml
+++ b/application/views/scripts/index/index.phtml
@@ -13,5 +13,5 @@
       <td><a target="graph_iframe" class="icon-clock" href="<?= urldecode($this->url) ?>&from=-1y">1 year</a></td>
     </tr>
   </table>
-  <iframe name ="graph_iframe" src="<?= urldecode($this->url) ?>&from=-1d" style="height: 700px; width: 800px" frameborder="no" scrolling="no"></iframe>
+  <iframe name ="graph_iframe" src="<?= urldecode($this->url) ?>&from=-1d" style="height: 700px; width: 800px" frameborder="no" scrolling="no" marginwidth="0" marginheight="0" hspace="0" vspace="0"></iframe>
 </div>

--- a/application/views/scripts/index/index.phtml
+++ b/application/views/scripts/index/index.phtml
@@ -13,5 +13,5 @@
       <td><a target="graph_iframe" class="icon-clock" href="<?= urldecode($this->url) ?>&from=-1y">1 year</a></td>
     </tr>
   </table>
-  <iframe name ="graph_iframe" src="<?= urldecode($this->url) ?>&from=-1d" style="height: 700px; width: 800px" frameborder="no"></iframe>
+  <iframe name ="graph_iframe" src="<?= urldecode($this->url) ?>&from=-1d" style="height: 700px; width: 800px" frameborder="no" scrolling="no"></iframe>
 </div>


### PR DESCRIPTION
Since Firefox defines by default a 8px margin to nested body, iframe always needs unuseful scrollbars.
