### PR TITLE
Add graphite_disable variable to siable all graphs on a given Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,15 @@ Composite graph definitions can get long and cumbersome, so you can define Label
     vars.graphite_keys = ["{used,max}", "{currentThreadsBusy,currentThreadCount}"]
     vars.graphite_labels = ["Heap", "Threads"]
 
+### Removing graphs
+To disable all graphs, add the following to your Service definition.  Note that you can put any string as the value; the presence of this variable is enough.
+
+    vars.grpahite_disable = "x"
+
 ## Hats off to
 
 This module borrows a lot from https://github.com/Icinga/icingaweb2-module-pnp4nagios
 
-## What it looks like		
+## What it looks like
 
 ![screen shot of graphite graph](https://raw.githubusercontent.com/philiphoy/icingaweb2-module-graphite/master/Capture.PNG)

--- a/library/Graphite/Grapher.php
+++ b/library/Graphite/Grapher.php
@@ -121,7 +121,11 @@ class Grapher extends GrapherHook
 
         $this->getKeysAndLabels(array(), $object->customvars);
         if (empty($this->graphiteKeys)) {
-          $this->getPerfDataKeys($object);
+            $this->getPerfDataKeys($object);
+        }
+        if (!empty($object->customvars["graphite_disable"])) {
+            $this->graphiteKeys = array();
+            $this->graphiteLabels = array();
         }
 
         if ($object instanceof Host) {


### PR DESCRIPTION
Regarding issue #62 
This adds a "graphite_disable" custom variable which, if specified, disables all graphs (As written in the comments, it just needs to be specified to any non-empty string to work).  It takes precedence over graphite_keys and graphite_labels.
I've tested this on my local IcingaWeb2 instance and it works great for me.  If you'd like me to do any other testing please let me know.

Thanks!
Usman
