### PR TITLE
use relative urls to allow running behind a proxy

### DIFF
--- a/application/controllers/IndexController.php
+++ b/application/controllers/IndexController.php
@@ -18,9 +18,7 @@ class Graphite_IndexController extends ActionController
         $this->view->iframe_h = $this->getParam('graphite_iframe_h');
 
         if ($this->grapher->getRemoteFetch()) {
-            $this->view->url = $this->_request->getScheme()."://".
-                               $this->_request->getHttpHost().
-                               Url::fromPath('graphite/index/graph', array(
+            $this->view->url = Url::fromPath('graphite/index/graph', array(
                                    'target' => $this->getParam('graphite_url')
                                ));
         } else {


### PR DESCRIPTION
We have icinga running as docker behind an nginx which manages certificates for HTTPS, so the scheme that icinga receives is not the public one. So, this plugin cannot know the real external url.

The solution is to use relative paths instead of absolute ones. And this is the patch.